### PR TITLE
Rebasing to Alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:3.9
+FROM lsiobase/nginx:3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm64v8-3.9
+FROM lsiobase/nginx:arm64v8-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm32v7-3.9
+FROM lsiobase/nginx:arm32v7-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,6 +49,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "22.02.19:", desc: "Rebasing to alpine 3.9." }
   - { date: "16.01.19:", desc: "Add pipeline logic and multi arch." }


### PR DESCRIPTION
This is part of a mass upgrade to 3.10. 

Basic smoke test should be performed before merging and notes should be tracked in the internal 3.10 Spreadsheet.